### PR TITLE
fix: rollup preset babel ouptut options

### DIFF
--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@react-native/typescript-config/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@crherman7/rechunk": ["../src/react-native"],
+      "@/*": ["./src/*"]
+    },
+    "types": ["react-native", "node"]
+  }
+}

--- a/src/rollup-preset/index.ts
+++ b/src/rollup-preset/index.ts
@@ -50,7 +50,19 @@ const BABEL_MODIFICATIONS = {
      * @param options - The existing options for the preset.
      * @returns The modified options with `enableBabelRuntime` set to `false`.
      */
-    '@react-native/babel-preset': (options: any) => ({
+    'module:@react-native/babel-preset': (options: any) => ({
+      ...options,
+      enableBabelRuntime: false,
+    }),
+    /**
+     * Updates the options for the `babel-preset-expo` preset.
+     *
+     * This modification function disables the `enableBabelRuntime` option in the preset.
+     *
+     * @param options - The existing options for the preset.
+     * @returns The modified options with `enableBabelRuntime` set to `false`.
+     */
+    'babel-preset-expo': (options: any) => ({
       ...options,
       enableBabelRuntime: false,
     }),
@@ -128,10 +140,7 @@ function modifyBabelConfig(
             if (rule === null) {
               return null; // Remove the plugin/preset
             } else if (typeof rule === 'function') {
-              return {
-                ...item,
-                options: rule((item as any).options || {}),
-              } as PluginItem; // Update options
+              return [nameOrPath, rule((item as any).options || {})];
             }
           }
         }
@@ -209,6 +218,7 @@ async function processOptions(options: RollupOptions) {
   const defaultOptions = {
     external,
     plugins: [
+      getBabelOutputPlugin({...babelConfigOptions}),
       image(),
       typescript({
         compilerOptions: {
@@ -220,13 +230,6 @@ async function processOptions(options: RollupOptions) {
         },
       }),
     ],
-    output: {
-      plugins: [
-        getBabelOutputPlugin({
-          ...babelConfigOptions,
-        }),
-      ],
-    },
     logLevel: 'silent',
   } satisfies RollupOptions;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,6 @@
 {
   "extends": "@react-native/typescript-config/tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@crherman7/rechunk": ["./src/react-native/index"],
-      "@/*": ["./example/src/*"]
-    },
     "types": ["react-native", "node"],
     "module": "ESNext"
   },


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

Babel configuration is not being applied to rollup preset.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

Normalize the babel configuration loaded from `loadPartialConfig` to `[PluginTarget, PluginOptions]` where `export type PluginTarget = string | object | ((...args: any[]) => any);` and `export type PluginOptions = object | undefined | false;`.

## Screenshots

<details>
  <summary>ios</summary>

![Simulator Screenshot - iPhone 15 - 2024-09-03 at 10 40 32](https://github.com/user-attachments/assets/8590628e-e26d-4186-a219-ebeb3c83dda4)
</details>

<details>
  <summary>android</summary>
  
![Screenshot_1725374500](https://github.com/user-attachments/assets/40a71c2e-0a19-4512-ae2a-ca09e6e6ffbf)
</details>

## How to Test

<!--

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

- Run the example app with the dev-server
- Proxy the requests and verify that you can see babel runtime helper functions as inline functions such as

```
function _objectWithoutProperties(e,t){if(null==e)return{};var o,r,i=_objectWithoutPropertiesLoose(e,t);if(Object.getOwnPropertySymbols){var s=Object.getOwnPropertySymbols(e);for(r=0;r<s.length;r++)o=s[r],t.includes(o)||{}.propertyIsEnumerable.call(e,o)&&(i[o]=e[o]);}return i;}
```

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

| | | |
| --- | --- | --- |
| Blocking | 🔴 ❌ 🚨 | RED |
| Non-blocking | 🟡 💡 🤔 💭 | Yellow, thinking, etc |
| Praise | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
