### PR TITLE
feat(cli): add typegen command for dynamic ReChunkEntries generation

### DIFF
--- a/packages/cli/src/cmds/index.ts
+++ b/packages/cli/src/cmds/index.ts
@@ -2,4 +2,5 @@ import './dev-server';
 import './init';
 import './list';
 import './publish';
+import './typegen';
 import './unpublish';

--- a/packages/cli/src/cmds/typegen.ts
+++ b/packages/cli/src/cmds/typegen.ts
@@ -1,5 +1,4 @@
 import {program} from 'commander';
-import path from 'path';
 import ts from 'typescript';
 
 import {

--- a/packages/cli/src/cmds/typegen.ts
+++ b/packages/cli/src/cmds/typegen.ts
@@ -1,0 +1,107 @@
+import {program} from 'commander';
+import path from 'path';
+import ts from 'typescript';
+
+import {
+  getRechunkConfig,
+  LOGO,
+  resolveDeclarationFilePathFromPackage,
+  withTS,
+} from '../lib';
+
+/**
+ * The name of the ReChunk package used for resolving paths and fetching its configuration.
+ *
+ * This constant is used throughout the codebase to refer to the ReChunk package. It ensures
+ * consistency when accessing the package's metadata, such as its `package.json`, TypeScript
+ * declaration files, and other related assets.
+ *
+ * @example
+ * Resolving the `package.json` for ReChunk:
+ * ```typescript
+ * const packageJsonPath = require.resolve(`${RECHUNK_PACKAGE}/package.json`, {
+ *   paths: [process.cwd()],
+ * });
+ * ```
+ */
+const RECHUNK_PACKAGE = '@crherman7/rechunk';
+
+/**
+ * Registers the `typegen` command to the `commander` CLI.
+ *
+ * The `typegen` command dynamically updates the `ReChunkEntries` type in the ReChunk
+ * library to reflect the latest entries from the `rechunk.json` configuration file. This
+ * ensures that the `importChunk` function accepts only the current valid chunk IDs.
+ *
+ * The updated type definitions are written to the `index.d.ts` file of the ReChunk library,
+ * keeping the typings consistent with the server-side configuration.
+ *
+ * @example
+ * Running the command via the CLI:
+ * ```bash
+ * yarn rechunk typegen
+ * ```
+ *
+ * Expected Behavior:
+ * - Reads the `rechunk.json` configuration to get the list of valid chunk entries.
+ * - Updates the `ReChunkEntries` type in the TypeScript declaration file (`index.d.ts`).
+ * - Ensures type safety and alignment between server-side configuration and client usage.
+ *
+ * @see {@link https://github.com/tj/commander.js} for more about the Commander.js library.
+ */
+program
+  .command('typegen')
+  .description('Update importChunk accepted chunks')
+  .action(async () => {
+    console.log();
+    console.log(LOGO);
+    console.log('🚀 Starting ReChunk Type Generation...`');
+
+    try {
+      // Fetch the ReChunk configuration
+      console.log('📄 Loading configuration from `rechunk.json`...');
+      const rc = getRechunkConfig();
+
+      const rechunkDeclarationFilePath =
+        resolveDeclarationFilePathFromPackage(RECHUNK_PACKAGE);
+
+      console.log(
+        `📁 Resolved type definitions path: ${rechunkDeclarationFilePath}`,
+      );
+
+      // Use withTS to update the ReChunkEntries type
+      console.log('🔍 Searching for `ReChunkEntries` type...');
+      withTS(
+        rechunkDeclarationFilePath,
+        (node: ts.Node): ts.Node | undefined => {
+          if (
+            ts.isTypeAliasDeclaration(node) &&
+            node.name.text === 'ReChunkEntries'
+          ) {
+            console.log('✅ Found `ReChunkEntries` type. Updating...');
+
+            // Replace the type definition with the union of valid chunk entries
+            return ts.factory.updateTypeAliasDeclaration(
+              node,
+              node.modifiers,
+              node.name,
+              node.typeParameters,
+              ts.factory.createUnionTypeNode(
+                Object.keys(rc.entry).map(entry =>
+                  ts.factory.createLiteralTypeNode(
+                    ts.factory.createStringLiteral(entry),
+                  ),
+                ),
+              ),
+            );
+          }
+
+          return undefined; // Return undefined for unmodified nodes
+        },
+      );
+
+      console.log('✨ Type definitions successfully updated! 🎉');
+    } catch (error) {
+      console.error('❌ Failed to update type definitions:', error);
+    }
+  });

--- a/packages/cli/src/lib/index.ts
+++ b/packages/cli/src/lib/index.ts
@@ -1,2 +1,4 @@
 export * from './config';
 export * from './constants';
+export * from './parsers';
+export * from './paths';

--- a/packages/cli/src/lib/parsers.ts
+++ b/packages/cli/src/lib/parsers.ts
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import ts from 'typescript';
+
+/**
+ * Applies a visitor function to the AST of a TypeScript file using the TypeScript Compiler API.
+ *
+ * This function reads a TypeScript file, applies the provided visitor function to its AST,
+ * and writes the modified file back to the same path.
+ *
+ * @param {string} filePath - The path to the TypeScript file.
+ * @param {(node: ts.Node) => ts.Node | undefined} visitor - The visitor function to apply to the AST.
+ *
+ * @example
+ * ```typescript
+ * import * as ts from 'typescript';
+ * import { withTS } from './withTS';
+ *
+ * const filePath = "/path/to/my-file.ts";
+ *
+ * // Visitor function to add a new property to an object literal
+ * const visitor = (node: ts.Node): ts.Node | undefined => {
+ *   if (ts.isObjectLiteralExpression(node)) {
+ *     // Create a new property
+ *     const newProperty = ts.factory.createPropertyAssignment(
+ *       ts.factory.createIdentifier('newProperty'),
+ *       ts.factory.createStringLiteral('newValue')
+ *     );
+ *
+ *     // Append the new property to the object literal
+ *     return ts.factory.updateObjectLiteralExpression(node, [
+ *       ...node.properties,
+ *       newProperty,
+ *     ]);
+ *   }
+ *   return node; // Return the original node if no transformation is applied
+ * };
+ *
+ * // Apply the visitor function to the AST of the file
+ * withTS(filePath, visitor);
+ *
+ * // The file at /path/to/my-file.ts will now include the added property in the object literal.
+ * ```
+ */
+export function withTS(
+  filePath: string,
+  visitor: (node: ts.Node) => ts.Node | undefined,
+): void {
+  // Read the source file content
+  const sourceText = fs.readFileSync(filePath, 'utf-8');
+
+  // Create a source file
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  // Create a transformer using the visitor function
+  const transformer = (context: ts.TransformationContext) => {
+    const visit: ts.Visitor = node => {
+      const updatedNode = visitor(node);
+      return ts.visitEachChild(updatedNode || node, visit, context);
+    };
+    return node => ts.visitNode(node, visit);
+  };
+
+  // Apply the transformer
+  const result = ts.transform(sourceFile, [transformer]);
+
+  // Get the transformed source file
+  const transformedSourceFile = result.transformed[0] as ts.SourceFile;
+
+  // Print the modified AST back to source code
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.LineFeed,
+  });
+  const modifiedSource = printer.printFile(transformedSourceFile);
+
+  // Write the modified source back to the file
+  fs.writeFileSync(filePath, modifiedSource, 'utf-8');
+}

--- a/packages/cli/src/lib/paths.ts
+++ b/packages/cli/src/lib/paths.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Resolves the path to the TypeScript declaration file (`index.d.ts`) for the given package
+ * by reading the `types` or `typings` field from its `package.json`.
+ *
+ * @param packageName - The name of the package whose declaration file path needs to be resolved.
+ * @returns The resolved path to the declaration file.
+ * @throws An error if the package or the declaration file cannot be found.
+ */
+export function resolveDeclarationFilePathFromPackage(
+  packageName: string,
+): string {
+  // Resolve the package.json path
+  const packageJsonPath = require.resolve(`${packageName}/package.json`, {
+    paths: [process.cwd()],
+  });
+
+  // Read and parse the package.json
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+  // Look for `types` or `typings` in the package.json
+  const typesPath = packageJson.types || packageJson.typings;
+
+  if (!typesPath) {
+    throw new Error(
+      `The package.json for ${packageName} does not specify a 'types' or 'typings' field.`,
+    );
+  }
+
+  // Resolve the types path relative to the package.json location
+  const declarationFilePath = path.resolve(
+    path.dirname(packageJsonPath),
+    typesPath,
+  );
+
+  if (!fs.existsSync(declarationFilePath)) {
+    throw new Error(
+      `Declaration file not found at resolved path: ${declarationFilePath}`,
+    );
+  }
+
+  return declarationFilePath;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,14 +7,16 @@ import './polyfill';
 import {TinyEmitter} from 'tiny-emitter';
 
 import {ChunkManager} from './ChunkManager';
-import type {Configuration} from './types';
+import type {Configuration, ValidateReChunkEntry} from './types';
 
 /**
  * Asynchronously imports a chunk using the shared ChunkManager instance.
  * @param {string} chunkId - The ID of the chunk to import.
  * @returns {Promise<*>} A promise resolving to the imported JavaScript component.
  */
-export async function importChunk(chunkId: string): Promise<any> {
+export async function importChunk<T extends string>(
+  chunkId: ValidateReChunkEntry<T>,
+): Promise<any> {
   // Using shared ChunkManager instance to import the chunk
   return ChunkManager.shared.importChunk(chunkId);
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,39 @@
 import {Chunk} from '@crherman7/rechunk-api-client';
 
 /**
+ * Represents the valid entries for chunks in the `importChunk` function.
+ *
+ * This type is updated dynamically during the `typegen` command execution.
+ * Initially, it is set to `null`, but it will be replaced with a union type of valid chunk names
+ * (e.g., `'card' | 'home' | 'stack'`).
+ *
+ * @example
+ * ```typescript
+ * type ReChunkEntries = 'card' | 'home' | 'stack';
+ * ```
+ */
+export type ReChunkEntries = null;
+
+/**
+ * Validates if a given chunk ID is part of the recognized `ReChunkEntries`.
+ *
+ * If the chunk ID is not valid, it produces a detailed error message prompting
+ * the user to regenerate types using the `typegen` command.
+ *
+ * @template T - The chunk ID to validate.
+ * @example
+ * ```typescript
+ * type ValidChunk = ValidateReChunkEntry<'card'>; // Resolves to 'card'
+ * type InvalidChunk = ValidateReChunkEntry<'invalid'>;
+ * // Resolves to:
+ * // "Invalid ReChunk entry: 'invalid' is not a recognized chunk ID. Please regenerate types using the `typegen` command."
+ * ```
+ */
+export type ValidateReChunkEntry<T extends string> = T extends ReChunkEntries
+  ? T
+  : `Invalid ReChunk entry: '${T}' is not a recognized chunk ID. Please ensure the chunk ID exists in the rechunk.json configuration file and regenerate types using the \`typegen\` command.`;
+
+/**
  * Makes all properties of a type and its nested types required recursively.
  *
  * @template T - The type to make all properties required for.


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

[closes TICKET-63](https://github.com/crherman7/rechunk/issues/63)

**Note** Merge after https://github.com/crherman7/rechunk/pull/62

## Implementation

1. **New `typegen` Command:**
   - Registers a `typegen` command in the CLI using the `commander` library.
   - Updates the `ReChunkEntries` type in the `index.d.ts` file dynamically based on `rechunk.json` entries.
   - Ensures the `importChunk` function only accepts valid chunk IDs.

2. **Enhanced TypeScript Type Definitions:**
   - Introduced `ValidateReChunkEntry<T>` to validate chunk IDs at the type level.
   - Improved error messages in `ValidateReChunkEntry<T>` with actionable instructions for regenerating types:
     ```typescript
     "Invalid ReChunk entry: '${T}' is not a recognized chunk ID. Please ensure the chunk ID exists 
     in the rechunk.json configuration file and regenerate types using the `typegen` command."
     ```

3. **`withTS` Utility for AST Transformations:**
   - Added a new `withTS` function to programmatically manipulate TypeScript AST using the TypeScript Compiler API.
   - Applied `withTS` in `typegen` to find and update the `ReChunkEntries` type.

4. **Improved Developer Experience:**
   - Added meaningful log messages with emojis for clarity and engagement during CLI execution.
   - Provided comprehensive TSDocs for `typegen`, `withTS`, and updated types, ensuring maintainability and ease of use.

## Screenshots

<details>
  <summary>editor</summary>

https://github.com/user-attachments/assets/dbd3a2d3-e726-4722-8e3f-8dc99b68d808
</details>

## How to Test

- Manually tested the typegen command to ensure:
        - It correctly updates the ReChunkEntries type based on rechunk.json.
        - It produces meaningful error messages for invalid chunk IDs.
- Verified AST manipulation through withTS for various scenarios.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

| | | |
| --- | --- | --- |
| Blocking | 🔴 ❌ 🚨 | RED |
| Non-blocking | 🟡 💡 🤔 💭 | Yellow, thinking, etc |
| Praise | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
