### PR TITLE
feat(ui): implement settings

### DIFF
--- a/apps/www/app/components/AutoResizeTextArea.tsx
+++ b/apps/www/app/components/AutoResizeTextArea.tsx
@@ -1,0 +1,39 @@
+import React, {useRef, useEffect, TextareaHTMLAttributes} from 'react';
+import {Textarea} from '~/components/ui/textarea'; // Adjust import path as needed
+
+interface AutoResizeTextareaProps
+  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  value?: string; // Optional prop for controlled components
+}
+
+const AutoResizeTextarea: React.FC<AutoResizeTextareaProps> = ({
+  value,
+  ...props
+}) => {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto'; // Reset height
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`; // Adjust to content height
+    }
+  }, [value]);
+
+  const handleInput = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const target = event.target;
+    target.style.height = 'auto'; // Reset height
+    target.style.height = `${target.scrollHeight}px`; // Adjust to content height
+  };
+
+  return (
+    <Textarea
+      {...props}
+      ref={textareaRef}
+      value={value}
+      onInput={handleInput}
+      style={{overflow: 'hidden', resize: 'none'}} // Prevent scrollbars and manual resizing
+    />
+  );
+};
+
+export default AutoResizeTextarea;

--- a/apps/www/app/components/Header.tsx
+++ b/apps/www/app/components/Header.tsx
@@ -12,7 +12,7 @@ export function Header({disableIcon = false}: HeaderProps) {
   const projectId = useProjectId();
 
   return (
-    <header className="border-b h-[57px] sticky top-0 flex flex-row items-center justify-between pr-4 backdrop-blur-[2px]">
+    <header className="border-b h-[57px] sticky top-0 flex flex-row items-center justify-between pr-4 backdrop-blur-[10px] z-10">
       <div className="flex flex-row justify-center items-center">
         {disableIcon ? (
           <></>

--- a/apps/www/app/components/LabeledInput.tsx
+++ b/apps/www/app/components/LabeledInput.tsx
@@ -1,0 +1,20 @@
+import {Input} from './ui/input';
+
+export const LabeledInput = ({
+  label,
+  value,
+  className = '',
+}: {
+  label: string;
+  value: string | undefined;
+  className?: string;
+}) => (
+  <div className="space-y-0.5 w-fit min-w-[350px]">
+    <p className="text-sm text-muted-foreground">{label}</p>
+    <Input
+      className={`w-full text-xs pointer-events-none ${className}`}
+      disabled
+      placeholder={value || ''}
+    />
+  </div>
+);

--- a/apps/www/app/components/LabeledTextArea.tsx
+++ b/apps/www/app/components/LabeledTextArea.tsx
@@ -1,0 +1,20 @@
+import AutoResizeTextarea from './AutoResizeTextArea';
+
+export const LabeledTextarea = ({
+  label,
+  value,
+  className = '',
+}: {
+  label: string;
+  value: string | undefined;
+  className?: string;
+}) => (
+  <div className="space-y-0.5">
+    <p className="text-sm text-muted-foreground">{label}</p>
+    <AutoResizeTextarea
+      disabled
+      className={`resize-none text-xs w-fit min-w-[525px] pointer-events-none text-slate-500 ${className}`}
+      value={value}
+    />
+  </div>
+);

--- a/apps/www/app/components/ui/separator.tsx
+++ b/apps/www/app/components/ui/separator.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "~/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/apps/www/app/components/ui/textarea.tsx
+++ b/apps/www/app/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import {cn} from '~/lib/utils';
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<'textarea'>
+  // eslint-disable-next-line react/prop-types
+>(({className, ...props}, ref) => {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = 'Textarea';
+
+export {Textarea};

--- a/apps/www/app/routes/_dashboard.settings.tsx
+++ b/apps/www/app/routes/_dashboard.settings.tsx
@@ -1,7 +1,65 @@
+import {json, LoaderFunctionArgs} from '@remix-run/node';
+import {useLoaderData} from '@remix-run/react';
+import {motion} from 'framer-motion';
+
+import {LabeledInput} from '~/components/LabeledInput';
+import {LabeledTextarea} from '~/components/LabeledTextArea';
+import {Separator} from '~/components/ui/separator';
+import {getProjectById} from '~/models/project.server';
+import {requireProjectId} from '~/session.server';
+
+export const loader = async ({request}: LoaderFunctionArgs) => {
+  const projectId = await requireProjectId(request);
+  const project = await getProjectById(projectId);
+
+  return json({
+    project: {
+      ...project,
+      createdAtFormatted: project?.createdAt
+        ? new Date(project.createdAt).toLocaleString()
+        : '',
+      updatedAtFormatted: project?.updatedAt
+        ? new Date(project.updatedAt).toLocaleString()
+        : '',
+    },
+  });
+};
 export default function Settings() {
+  const {project} = useLoaderData<typeof loader>();
+
   return (
-    <div className="flex justify-center items-center">
-      <h1 className="font-mono text-3xl text-muted">/settings</h1>
-    </div>
+    <motion.div
+      initial={{opacity: 0}}
+      animate={{opacity: 1}}
+      transition={{duration: 1}}
+      className="space-y-6 p-10 overflow-x-auto">
+      <div className="space-y-0.5">
+        <h2 className="text-2xl font-bold tracking-tight">Settings</h2>
+        <p className="text-sm text-muted-foreground">
+          Manage your account settings.
+        </p>
+      </div>
+      <Separator className="my-6" />
+      <div className="space-y-4">
+        <h3 className="text-xl font-bold tracking-tight">Project</h3>
+        <LabeledInput label="Identifier" value={project.id} />
+        <LabeledInput label="Created At" value={project.createdAtFormatted} />
+        <LabeledInput label="Updated At" value={project.updatedAtFormatted} />
+      </div>
+      <Separator className="my-6" />
+      <div className="space-y-4 pr-4">
+        <h3 className="text-xl font-bold tracking-tight">
+          Authentication Keys
+        </h3>
+        <LabeledInput label="Read Key" value={project.readKey} />
+        <LabeledInput label="Write Key" value={project.writeKey} />
+      </div>
+      <Separator className="my-6" />
+      <div className="space-y-4">
+        <h3 className="text-xl font-bold tracking-tight">Cryptographic Keys</h3>
+        <LabeledTextarea label="Public Key" value={project.publicKey} />
+        <LabeledTextarea label="Private Key" value={project.privateKey} />
+      </div>
+    </motion.div>
   );
 }

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@remix-run/node": "^2.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.0
         version: 2.1.0(@types/react-dom@18.3.0)(@types/react@18.2.65)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.2.65)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.2.65)(react@18.2.0)
@@ -2626,6 +2629,19 @@ packages:
 
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.0':
+    resolution: {integrity: sha512-3uBAs+egzvJBDZAzvb/n4NxxOYpnspmWxO2u5NbZ8Y6FM/NdrGSF9bop3Cf6F6C71z1rTSn8KV0Fo2ZVd79lGA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -12028,6 +12044,15 @@ snapshots:
   '@radix-ui/react-primitive@2.0.0(@types/react-dom@18.3.0)(@types/react@18.2.65)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.2.65)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.65
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-separator@1.1.0(@types/react-dom@18.3.0)(@types/react@18.2.65)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.2.65)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
     optionalDependencies:


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

[closes TICKET-58](https://github.com/crherman7/rechunk/issues/58)

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

### **Settings Route**

#### Overview
The `settings` route serves as a dashboard page for managing project settings. It uses Remix.run's loader and React's client-side rendering for displaying project details, authentication keys, and cryptographic keys.

### **Features**

1. **Loader Functionality**
   - Fetches the `projectId` from the session using `requireProjectId`.
   - Retrieves the project details from the server via `getProjectById`.
   - Formats `createdAt` and `updatedAt` timestamps for display.

2. **UI Components**
   - Uses a variety of components (`LabeledInput`, `LabeledTextarea`, `Separator`, etc.) for a structured and accessible UI.
   - Dynamically adjusts text area sizes using `AutoResizeTextArea`.

3. **Animation**
   - Page transition animation with `framer-motion` for a smooth user experience.

4. **Read-Only View**
   - Settings are displayed in a read-only format, with keys and cryptographic data being non-editable for security.

## Screenshots

<details>
  <summary>browser</summary>

  <!--

  Add device screenshot here.

   -->

https://github.com/user-attachments/assets/3d8b3a81-c46d-4145-b89d-463157a3aa7c
</details>

## How to Test

<!--

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

- `pnpm install`
- `cd apps/www`
- `cp .env.example` `.env`
- `pnpm seed`
- `pnpm dev`
- Click "Get Started"
- Login with id/write key: `cm38wkhur0000yseh1beq2hpx`/`write-2b05d863-6100-458b-b527-bc5a9d0b2061`
- Verify you get redirected to `/chunks` route
- Click the settings icon
- Verify you get redirected to `/settings` route and see the project attributes

**Note** currently we are exposing the `writeKey` in the dashboard and it is stored as a raw value - in the future we likely should encrypting these values.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

| | | |
| --- | --- | --- |
| Blocking | 🔴 ❌ 🚨 | RED |
| Non-blocking | 🟡 💡 🤔 💭 | Yellow, thinking, etc |
| Praise | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
